### PR TITLE
quoine btcusd

### DIFF
--- a/fetchAllTickData.js
+++ b/fetchAllTickData.js
@@ -83,7 +83,7 @@ async function fetchQuoineJPY() {
   return new TickData('JPY', quoine.id, ticker['bid'], ticker['ask'], ticker['baseVolume'], ticker['timestamp'])
 }
 
-async function fetchQuoineBTC() {
+async function fetchQuoineUSD() {
   let ticker = await quoine.fetchTicker('BTC/USD')
   return new TickData('USD', 'quoine-usd', ticker['bid'], ticker['ask'], ticker['baseVolume'], ticker['timestamp'])
 }

--- a/fetchAllTickData.js
+++ b/fetchAllTickData.js
@@ -2,24 +2,24 @@ const ccxt = require('ccxt')
 const rp = require('request-promise')
 const TickData = require('./tickData')
 
-var gemini = ccxt.gemini()
-var bitstamp = ccxt.bitstamp()
-var gdax = ccxt.gdax()
-var lakebtc = ccxt.lakebtc()
-var kraken = ccxt.kraken()
+var gemini = new ccxt.gemini()
+var bitstamp = new ccxt.bitstamp()
+var gdax = new ccxt.gdax()
+var lakebtc = new ccxt.lakebtc()
+var kraken = new ccxt.kraken()
 // USDT
-var bitfinex = ccxt.bitfinex() // Bittrex support USDT & USD
-var poloniex = ccxt.poloniex()
-var binance = ccxt.binance()
-var hitbtc = ccxt.hitbtc2()
-var bittrex = ccxt.bittrex()
+var bitfinex = new ccxt.bitfinex() // Bittrex support USDT & USD
+var poloniex = new ccxt.poloniex()
+var binance = new ccxt.binance()
+var hitbtc = new ccxt.hitbtc2()
+var bittrex = new ccxt.bittrex()
 // JPY
-var coincheck = ccxt.coincheck()
-var zaif = ccxt.zaif()
-var bitflyer = ccxt.bitflyer()
-var quoine = ccxt.quoine()
+var coincheck = new ccxt.coincheck()
+var zaif = new ccxt.zaif()
+var bitflyer = new ccxt.bitflyer()
+var quoine = new ccxt.quoine()
 // KRW
-var bithumb = ccxt.bithumb()
+var bithumb = new ccxt.bithumb()
 // support korbit
 // support coinone
 
@@ -85,7 +85,7 @@ async function fetchQuoineJPY() {
 
 async function fetchQuoineBTC() {
   let ticker = await quoine.fetchTicker('BTC/USD')
-  return new TickData('USD', quoine.id, ticker['bid'], ticker['ask'], ticker['baseVolume'], ticker['timestamp'])
+  return new TickData('USD', 'quoine-usd', ticker['bid'], ticker['ask'], ticker['baseVolume'], ticker['timestamp'])
 }
 
 

--- a/fetchAllTickData.js
+++ b/fetchAllTickData.js
@@ -78,10 +78,16 @@ async function fetchBitflyer() {
   return new TickData('JPY', bitflyer.id, ticker['bid'], ticker['ask'], ticker['baseVolume'], ticker['timestamp'])
 }
 
-async function fetchQuoine() {
+async function fetchQuoineJPY() {
   let ticker = await quoine.fetchTicker('BTC/JPY')
   return new TickData('JPY', quoine.id, ticker['bid'], ticker['ask'], ticker['baseVolume'], ticker['timestamp'])
 }
+
+async function fetchQuoineBTC() {
+  let ticker = await quoine.fetchTicker('BTC/USD')
+  return new TickData('USD', quoine.id, ticker['bid'], ticker['ask'], ticker['baseVolume'], ticker['timestamp'])
+}
+
 
 async function fetchZaif() {
   let ticker = await zaif.fetchTicker('BTC/JPY')
@@ -122,7 +128,8 @@ async function fetchAllTickData() {
     fetchHitbtc(),
     fetchCoincheck(),
     fetchBitflyer(),
-    fetchQuoine(),
+    fetchQuoineJPY(),
+    fetchQuoineUSD(),
     fetchZaif(),
     fetchBithumb(),
     fetchKorbit(),


### PR DESCRIPTION
- quoineのbtc-usdもfetch

fusion table側でカラムを追加したつもりができていない。

```
 Error: Invalid query: Expected 60 values, but got 63 for 'date', 'GLBI', 'JBI', 'KRBI', 'USBI', 'USDTBI', 'USD_JPY', 'USD_KRW', 'JPY_USD', 'JPY_KRW', 'KRW_USD', 'KRW_JPY', 'bittrex_bid', 'bittrex_ask', 'bittrex_volume', 'bitstamp_bid', 'bitstamp_ask', 'bitstamp_volume', 'lakebtc_bid', 'lakebtc_ask', 'lakebtc_volume', 'gemini_bid', 'gemini_ask', 'gemini_volume', 'gdax_bid', 'gdax_ask', 'gdax_volume', 'bitfinex_bid', 'bitfinex_ask', 'bitfinex_volume', 'poloniex_bid', 'poloniex_ask', 'poloniex_volume', 'binance_bid', 'binance_ask', 'binance_volume', 'hitbtc_bid', 'hitbtc_ask', 'hitbtc_volume', 'coincheck_bid', 'coincheck_ask', 'coincheck_volume', 'bitflyer_bid', 'bitflyer_ask', 'bitflyer_volume', 'quoine_bid', 'quoine_ask', 'quoine_volume', 'aif_bid', 'zaif_ask', 'zaif_volume', 'bithumb_bid', 'bithumb_ask', 'bithumb_volume', 'korbit_bid', 'korbit_ask', 'korbit_volume', 'coinone_bid', 'coinone_ask', 'coinone_volume'
    at Request._callback (/Users/take/Develop/bitcoin-global-index/node_modules/google-auth-library/lib/transporters.js:85:15)
    at Request.self.callback (/Users/take/Develop/bitcoin-global-index/node_modules/request/request.js:186:22)
    at emitTwo (events.js:126:13)
    at Request.emit (events.js:214:7)
    at Request.<anonymous> (/Users/take/Develop/bitcoin-global-index/node_modules/request/request.js:1163:10)
    at emitOne (events.js:116:13)
    at Request.emit (events.js:211:7)
    at IncomingMessage.<anonymous> (/Users/take/Develop/bitcoin-global-index/node_modules/request/request.js:1085:12)
    at Object.onceWrapper (events.js:313:30)
    at emitNone (events.js:111:20)
    at IncomingMessage.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1056:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
  code: 400,
  errors:
   [ { domain: 'fusiontables',
       reason: 'badQueryCouldNotParse',
       message: 'Invalid query: Expected 60 values, but got 63 for \'date\', \'GLBI\', \'JBI\', \'KRBI\', \'USBI\', \'USDTBI\', \'USD_JPY\', \'USD_KRW\', \'JPY_USD\', \'JPY_KRW\', \'KRW_USD\', \'KRW_JPY\', \'bittrex_bid\', \'bittrex_ask\', \'bittrex_volume\', \'bitstamp_bid\', \'bitstamp_ask\', \'bitstamp_volume\', \'lakebtc_bid\', \'lakebtc_ask\', \'lakebtc_volume\', \'gemini_bid\', \'gemini_ask\', \'gemini_volume\', \'gdax_bid\', \'gdax_ask\', \'gdax_volume\', \'bitfinex_bid\', \'bitfinex_ask\', \'bitfinex_volume\', \'poloniex_bid\', \'poloniex_ask\', \'poloniex_volume\', \'binance_bid\', \'binance_ask\', \'binance_volume\', \'hitbtc_bid\', \'hitbtc_ask\', \'hitbtc_volume\', \'coincheck_bid\', \'coincheck_ask\', \'coincheck_volume\', \'bitflyer_bid\', \'bitflyer_ask\', \'bitflyer_volume\', \'quoine_bid\', \'quoine_ask\', \'quoine_volume\', \'aif_bid\', \'zaif_ask\', \'zaif_volume\', \'bithumb_bid\', \'bithumb_ask\', \'bithumb_volume\', \'korbit_bid\', \'korbit_ask\', \'korbit_volume\', \'coinone_bid\', \'coinone_ask\', \'coinone_volume\'',
       locationType: 'parameter',
       location: 'q' } ] }
```